### PR TITLE
Add egg package name to avoid issues after pip freeze

### DIFF
--- a/tools/llm_bench/requirements.txt
+++ b/tools/llm_bench/requirements.txt
@@ -11,8 +11,8 @@ torch
 transformers>=4.40.0
 diffusers>=0.22.0
 #optimum is in dependency list of optimum-intel 
-git+https://github.com/huggingface/optimum-intel.git@main
-git+https://github.com/openvinotoolkit/nncf.git@develop
+git+https://github.com/huggingface/optimum-intel.git@main#egg=optimum-intel
+git+https://github.com/openvinotoolkit/nncf.git@develop#egg=nncf
 packaging
 psutil
 timm


### PR DESCRIPTION
In CI we are reusing frozen requirements after `convert` job, installing them in `test` jobs. When there is no egg name defined, `pip freeze -r requirements.txt` is returning warning as following:

```
--extra-index-url https://download.pytorch.org/whl/cpu
numpy==2.1.3
--extra-index-url https://storage.openvinotoolkit.org/simple/wheels/pre-release
--extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
openvino @ file:///nfs/ov-share-03/data/volatile/openvino_ci/private_builds/dldt/master/commit/9d51a16314595f487e7dbc57c1327321d6c3a5a2/private_linux_manylinux2014_release/wheels/openvino-2025.1.0.dev20250209-18110-cp310-cp310-manylinux2014_x86_64.whl#sha256=125b848dd344b5d3e3174eceaa3578cf12e718251e4c448e3c54fbc66240e5ba
openvino-tokenizers @ file:///nfs/ov-share-03/data/volatile/openvino_ci/private_builds/dldt/master/commit/9d51a16314595f487e7dbc57c1327321d6c3a5a2/private_linux_manylinux2014_release/wheels/openvino_tokenizers-2025.1.0.0.dev20250209-py3-none-manylinux2014_x86_64.whl#sha256=76f5038719e0c70389e2dbd843ad92568c59b67a7b9bf53f135080209b2a4009
openvino-genai @ file:///nfs/ov-share-03/data/volatile/openvino_ci/private_builds/dldt/master/commit/9d51a16314595f487e7dbc57c1327321d6c3a5a2/private_linux_manylinux2014_release/wheels/openvino_genai-2025.1.0.0.dev20250209-cp310-cp310-manylinux2014_x86_64.whl#sha256=1f8a475316317367a2388a318ffb956d55ba16110cbddc1183a7d947eafa45fc
auto_gptq==0.7.1
pillow==11.1.0
torch==2.6.0+cpu
transformers==4.48.3
diffusers==0.32.2
#optimum is in dependency list of optimum-intel
Skipping line in requirement file [repo_llm/tools/llm_bench/requirements.txt] because it's not clear what it would install: git+https://github.com/huggingface/optimum-intel.git@main
  (add #egg=PackageName to the URL to avoid this warning)
Skipping line in requirement file [repo_llm/tools/llm_bench/requirements.txt] because it's not clear what it would install: git+https://github.com/openvinotoolkit/nncf.git@develop
  (add #egg=PackageName to the URL to avoid this warning)
packaging==24.2
psutil==6.1.1
timm==1.0.14
tiktoken==0.8.0
onnx==1.17.0
einops==0.8.1
transformers-stream-generator==0.0.5
bitsandbytes==0.45.2
librosa==0.10.2.post1
```

and that is causing `optimum-intel` and `nncf` not being installed in test jobs and benchmarks failing